### PR TITLE
Read hashReserved from disk instead of assuming 0, to avoid sync issues

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -304,6 +304,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nUndoPos       = diskindex.nUndoPos;
                 pindexNew->hashAnchor     = diskindex.hashAnchor;
                 pindexNew->nVersion       = diskindex.nVersion;
+                pindexNew->hashReserved   = diskindex.hashReserved;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;


### PR DESCRIPTION
This bug will cause network sync issues when miners use BTG software which puts the blockHeight in hashReserved, original Zcash upstream bug is here: https://github.com/zcash/zcash/pull/2931

ZEN, HUSH, KMD have fixed this sync issue already, and BTCZ is starting to notice the problem on their network. All Zcash source code forks I have looked at have this issue and should fix this bug before network sync issues *force* you to deal with it.